### PR TITLE
fix: control now no longer has MemoryAddress

### DIFF
--- a/ctowasm/src/interpreter/controlItems/instructions.ts
+++ b/ctowasm/src/interpreter/controlItems/instructions.ts
@@ -1,9 +1,7 @@
 import { BinaryOperator, ScalarCDataType } from "~src/common/types";
 import { CNodeP, ExpressionP } from "~src/processor/c-ast/core";
-import { BinaryExpressionP } from "~src/processor/c-ast/expression/expressions";
 import { CalledFunction, FunctionDetails } from "~src/processor/c-ast/function";
-import { Address, DynamicAddress } from "~src/processor/c-ast/memory";
-import { Control, ControlItem } from "~src/interpreter/utils/control";
+import { ControlItem } from "~src/interpreter/utils/control";
 
 /**
  * Types of instructions for the interpreter
@@ -23,7 +21,6 @@ export enum InstructionType {
   CASE_JUMP = "CASE_JUMP",
   CASE_MARK = "CASE_MARK",
   CONTINUE_MARK = "CONTINUE_MARK",
-  TYPE_CONVERSION = "TYPE_CONVERSION",
 }
 
 export interface BaseInstruction {
@@ -237,16 +234,6 @@ export function doCaseInstructionsMatch(
   return jumpInstruction.caseValue === markInstruction.caseValue;
 }
 
-export interface TypeConversionInstruction extends BaseInstruction {
-  type: InstructionType.TYPE_CONVERSION;
-  targetType: ScalarCDataType;
-}
-
-export const typeConversionInstruction = (targetType: ScalarCDataType): TypeConversionInstruction => ({
-  type: InstructionType.TYPE_CONVERSION,
-  targetType,
-})
-
 export type Instruction = 
   | BinaryOpInstruction
   | UnaryOpInstruction
@@ -262,8 +249,7 @@ export type Instruction =
   | BreakMarkInstruction
   | CaseJumpInstruction
   | CaseMarkInstruction
-  | ContinueMarkInstruction
-  | TypeConversionInstruction;
+  | ContinueMarkInstruction;
 
 export const isInstruction = (item: any): item is Instruction => {
   return item && typeof item === 'object' && 'type' in item && 

--- a/ctowasm/src/interpreter/runtime.ts
+++ b/ctowasm/src/interpreter/runtime.ts
@@ -12,6 +12,7 @@ import {
   resolveValueToConstantP,
   RuntimeMemoryPair
 } from "~src/interpreter/utils/addressUtils";
+import { ScalarCDataType } from "~src/common/types";
 
 export class Runtime {
   private readonly control: Control;
@@ -111,7 +112,7 @@ export class Runtime {
         type: "MemoryWriteInterface",
         address: pair.address.value,
         value: writeValue,
-        dataType: pair.address.dataType
+        dataType: pair.dataType,
       };
     });
 
@@ -122,8 +123,8 @@ export class Runtime {
     );
   }
 
-  memoryLoad(address: MemoryAddress) {
-    const value = this.memory.load(address);
+  memoryLoad(address: MemoryAddress, dataType: ScalarCDataType) {
+    const value = this.memory.load(address, dataType);
     const [ _, newRuntime ] = this.popValue();
     return newRuntime.pushValue(value);
   }

--- a/ctowasm/src/interpreter/utils/addressUtils.ts
+++ b/ctowasm/src/interpreter/utils/addressUtils.ts
@@ -1,90 +1,37 @@
-import { SharedWasmGlobalVariables } from "~dist";
 import { ScalarCDataType } from "~src/common/types";
-import { CNodePBase } from "~src/processor/c-ast/core";
 import { ConstantP } from "~src/processor/c-ast/expression/constants";
-import { Address } from "~src/processor/c-ast/memory";
-import { typeConversionInstruction } from "~src/interpreter/controlItems/instructions";
-import { ControlItem } from "~src/interpreter/utils/control";
 
 export interface RuntimeMemoryPair {
   type: "RuntimeMemoryPair";
   address: MemoryAddress;
   value: MemoryAddress | ConstantP;
-}
-
-export interface MemoryAddress extends CNodePBase{
-  type: "MemoryAddress";
-  value: bigint;
-  hexValue: string;
   dataType: ScalarCDataType;
 }
 
-export function createMemoryAddress(value: bigint, dataType: ScalarCDataType): MemoryAddress {
+export interface MemoryAddress {
+  type: "MemoryAddress";
+  value: bigint;
+  hexValue: string;
+}
+
+export function createMemoryAddress(value: bigint): MemoryAddress {
   return {
     type: "MemoryAddress",
     value,
     hexValue: `0x${value.toString(16).padStart(8, '0')}`,
-    dataType,
   };
 }
 
 export function resolveValueToConstantP(value: MemoryAddress | ConstantP): ConstantP {
-    // if ConstantP return itself
-    if (value.type === "IntegerConstant" || value.type === "FloatConstant") {
-      return value;
-    }
-
-    // if MemoryAddress convert it to an unsigned int (equivalent)
-    return {
-      type: "IntegerConstant",
-      value: value.value,
-      dataType: "unsigned int"
-    }
+  // if ConstantP return itself
+  if (value.type === "IntegerConstant" || value.type === "FloatConstant") {
+    return value;
   }
 
-export function convertAddressNodes(
-  address: Address,
-  dataType: ScalarCDataType, 
-  isLoad: boolean, 
-  memoryPointers: SharedWasmGlobalVariables
-): ControlItem[] {
-  switch(address.type) {
-    case "LocalAddress":
-      return [createMemoryAddress(
-        BigInt(memoryPointers.basePointer.value) + address.offset.value,
-        dataType
-      )];
-    case "DataSegmentAddress":
-      return [createMemoryAddress(
-        address.offset.value,
-        dataType
-      )];
-    case "DynamicAddress":
-      return [
-        address.address,
-        typeConversionInstruction(dataType),
-      ]
-    case "FunctionTableIndex":
-      throw new Error("Memory for FunctionTableIndex not implemented")
-    case "ReturnObjectAddress":
-      if (isLoad) {
-        if (address.subtype !== "load") {
-          throw new Error("Expected 'load' in ReturnObjectAddress");
-        }
-
-        return [createMemoryAddress(
-          BigInt(memoryPointers.stackPointer.value) + address.offset.value,
-          dataType
-        )];
-      }
-
-      if(address.subtype !== "store") {
-        throw new Error("Expected 'store' in ReturnObjectAddress");
-      }
-
-      return [createMemoryAddress(
-        BigInt(memoryPointers.basePointer.value) + address.offset.value,
-        dataType
-      )];
+  // if MemoryAddress convert it to an unsigned int (equivalent)
+  return {
+    type: "IntegerConstant",
+    value: value.value,
+    dataType: "unsigned int"
   }
 }

--- a/ctowasm/src/interpreter/utils/constantsUtils.ts
+++ b/ctowasm/src/interpreter/utils/constantsUtils.ts
@@ -22,15 +22,12 @@ export function performConstantAndAddressBinaryOperation(
   let cLeft = left;
   let cRight = right;
   let addressReturn: boolean = false;
-  let addressDataType: ScalarCDataType | undefined;
 
   if (Stash.isMemoryAddress(cLeft)) {
-    addressDataType = cLeft.dataType;
     cLeft = convertMemoryAddressToConstant(cLeft);
     addressReturn = true;
   }
   if (Stash.isMemoryAddress(cRight)) {
-    addressDataType = cRight.dataType;
     cRight = convertMemoryAddressToConstant(cRight);
     addressReturn = true;
   }
@@ -57,8 +54,8 @@ export function performConstantAndAddressBinaryOperation(
       dataType.primaryDataType,
     );
 
-    if (addressReturn && addressDataType) {
-      return createMemoryAddress(valueInt, addressDataType)
+    if (addressReturn) {
+      return createMemoryAddress(valueInt);
     }
 
     return {

--- a/ctowasm/src/interpreter/utils/control.ts
+++ b/ctowasm/src/interpreter/utils/control.ts
@@ -30,7 +30,6 @@ export class Control extends Stack<ControlItem, Control> {
           item.type === InstructionType.BRANCH ||
           item.type === InstructionType.POP ||
           item.type === InstructionType.WHILE ||
-          item.type === InstructionType.MEMORY_STORE ||
           item.type === InstructionType.BREAK_MARK ||
           item.type === InstructionType.CONTINUE_MARK
         ) {
@@ -41,13 +40,10 @@ export class Control extends Stack<ControlItem, Control> {
         ) {
           result += `  ${itemPosition}. [Instruction] ${item.type}: '${item.caseValue}'\n`;
         } else if (
-          item.type === InstructionType.MEMORY_LOAD 
+          item.type === InstructionType.MEMORY_LOAD ||
+          item.type === InstructionType.MEMORY_STORE
         ) {
           result += `  ${itemPosition}. [Instruction] ${item.type}: '${item.dataType}'\n`;
-        } else if (
-          item.type === InstructionType.TYPE_CONVERSION
-        ) {
-          result += `  ${itemPosition}. [Instruction] ${item.type}: '${item.targetType}'\n`
         } else {
           result += `  ${itemPosition}. [Instruction] ${item.type}\n`
         }

--- a/ctowasm/src/interpreter/utils/stash.ts
+++ b/ctowasm/src/interpreter/utils/stash.ts
@@ -37,10 +37,10 @@ export class Stash extends Stack<StashItem, Stash> {
           displayValue = `${item.value}`;
           break;
         case "MemoryAddress":
-          displayValue = `MemoryAddress(address: ${item.hexValue}, type: ${item.dataType})`;
+          displayValue = `MemoryAddress (${item.hexValue})`;
           break;
         case "FunctionTableIndex":
-          displayValue = `FunctionTableIndex(${item.index.value})`;
+          displayValue = `FunctionTableIndex (${item.index.value})`;
         default:
           break;
       }

--- a/ctowasm/src/processor/c-ast/core.ts
+++ b/ctowasm/src/processor/c-ast/core.ts
@@ -29,13 +29,11 @@ import { PrimaryDataTypeMemoryObjectDetails } from "~src/processor/dataTypeUtil"
 import { ModuleName } from "~src/modules";
 import { FunctionTable } from "~src/processor/symbolTable";
 import { ExpressionStatementP } from "./statement/expressionStatement";
-import { MemoryAddress } from "~src/interpreter/utils/addressUtils";
 
 export type CNodeP = 
   | FunctionDefinitionP 
   | StatementP
-  | ExpressionP 
-  | MemoryAddress;
+  | ExpressionP;
 
 /**
  * Every processed C AST node should extend this interface.


### PR DESCRIPTION
- Removed MemoryAddress from ControlItem
- Instead, NodeAddresses (eg. LocalAddress) are stored on the Control and when pushed to the Stash, it is converted to a MemoryAddress. This makes calculations much easier especially for things like struct and arrays.